### PR TITLE
Potential fix for code scanning alert no. 4: Exception text reinterpreted as HTML

### DIFF
--- a/src/bindingWS.ts
+++ b/src/bindingWS.ts
@@ -11,6 +11,22 @@ import * as admin from 'firebase-admin';
 import { IssueOrganization, GroupOrganization, Group, MemberOrganization, Member } from './model';
 const uuidv4 = require('uuid').v4;
 
+// Utility to escape HTML meta-characters (minimal version)
+function escapeHTML(str: string): string {
+    if (typeof str !== 'string') return str;
+    return str.replace(/[&<>"'`]/g, function (char) {
+        const map: { [char: string]: string } = {
+            '&': '&amp;',
+            '<': '&lt;',
+            '>': '&gt;',
+            '"': '&quot;',
+            "'": '&#39;',
+            '`': '&#x60;'
+        };
+        return map[char];
+    });
+}
+
 const router = Router()
 router.post('/Binding', async function (req, res) {
     const applicationName = config.appName
@@ -34,7 +50,7 @@ router.post('/Binding', async function (req, res) {
                 break
             case "login":
                 result = await login(lineId, data, applicationName).catch(err => {
-                    res.status(403).send(err)
+                    res.status(403).json({ error: escapeHTML(err.toString()) })
                 })
                 console.log("result", result)
                 res.send(result)
@@ -42,7 +58,7 @@ router.post('/Binding', async function (req, res) {
             case "groupBinding":
                 result = await groupBinding(lineId, data, applicationName).then(() => {
                 }).catch(err => {
-                    res.status(403).send(err)
+                    res.status(403).json({ error: escapeHTML(err.toString()) })
                 })
                 console.log("result", result)
                 res.send(result)


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/4](https://github.com/jkes900136/messagingSystem/security/code-scanning/4)

The best way to fix this problem is to sanitize or encode error messages before sending them back to the client, particularly when the frontend might render them in the DOM. In Express, you should avoid sending raw error strings. Instead, wrap the error message with a JSON object and string type that does not allow for HTML interpretation, or use contextual encoding (e.g., escape HTML). The change should be made in `src/bindingWS.ts`, specifically in error handling blocks in `/Binding` route, at lines where `res.status(403).send(err)` might be called.

Recommended fix:
- Change error handler to send errors as `{ error: message }` JSON, where `message` is encoded (HTML escaped), or (to be safe) as plain text but with explicit encoding applied.
- Add a simple utility to escape HTML meta-characters (using a well-known library like `he`, or implement a minimal escape function if you can't add new dependencies).
- Replace lines like `res.status(403).send(err)` with something like `res.status(403).json({ error: escape(err.toString()) })`, ensuring that any user-controllable content in `err` is encoded.

Required changes:
- Add an HTML-escaping utility function.
- Update the error handlers at lines 37 and 45 to use this escape and send JSON rather than bare strings.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
