### PR TITLE
Potential fix for code scanning alert no. 6: Server-side URL redirect

### DIFF
--- a/src/messageRecordWS.ts
+++ b/src/messageRecordWS.ts
@@ -11,7 +11,11 @@ router.get("/urlRedirect", (req, res) => {
     if (trackId != "system") {
         urlOpender(trackId)
     }
-    res.redirect(url)
+    if (isSafeRedirectTarget(url)) {
+        res.redirect(url)
+    } else {
+        res.redirect("/")
+    }
 })
 router.post("/memberTimer", (req, res) => {
     let member = req.body
@@ -81,6 +85,18 @@ const urlOpender = async (trackId: string) => {
     // }
 }
 
+// Allow only relative URLs as redirect targets
+function isSafeRedirectTarget(url: any): boolean {
+    // Only allow string, and only relative URLs (no protocol, no domain)
+    if (typeof url !== "string") return false;
+    // Disallow protocol-relative and fully qualified URLs
+    if (/^(\w+:)?\/\//.test(url)) return false;
+    // Disallow absolute file-system paths (optional)
+    // Optionally, allow only URLs starting with /
+    if (!url.startsWith("/")) return false;
+    // Optionally, add further path sanitization here
+    return true;
+}
 
 // router.get("/syncGAData", async (req, res) => {
 //     const records = await getMessageRecord()


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/6](https://github.com/jkes900136/messagingSystem/security/code-scanning/6)

To fix this problem, we must ensure the redirection target is not under the attacker's control. The recommended, least-change fix is to only permit redirects to safe, known-good locations. This can be achieved by maintaining an explicit whitelist of allowed URLs or restricting redirection to relative paths within the application (i.e., paths that do not switch domain or protocol). For most cases, ensuring that the target `url` is a local path (does not start with `http://`, `https://`, or `//` and resolves to the same origin) is the best guarantee.

We will implement an `isSafeRedirectTarget` function that allows only:
- Relative URLs (not absolute, not protocol-relative)
- Paths not containing hostnames or protocols.

If `url` fails validation, we redirect to a default (safe) path such as `/`. This logic will be applied directly in the `/urlRedirect` route.

We need to:
- Add the `isSafeRedirectTarget` helper function in `src/messageRecordWS.ts`
- Replace the use of `res.redirect(url)` with a version that checks if the URL is safe, otherwise falls back to `/`

No new dependencies are required for this.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
