### PR TITLE
Potential fix for code scanning alert no. 20: Server-side URL redirect

### DIFF
--- a/src/messageRecordWS.ts
+++ b/src/messageRecordWS.ts
@@ -5,14 +5,32 @@ import { RecordDetail, MessageRecord } from "./model"
 
 const router = Router()
 
+// Whitelist of explicitly allowed relative targets
+const ALLOWED_REDIRECT_TARGETS = [
+    "/",               // homepage
+    "/dashboard",
+    "/profile",
+    // Add more allowed relative routes as needed
+];
+
+// Helper: returns the safe redirect target if allowed
+function getAllowedRedirectTarget(url: any): string | null {
+    if (typeof url !== "string") return null;
+    if (ALLOWED_REDIRECT_TARGETS.includes(url)) {
+        return url;
+    }
+    return null;
+}
+
 router.get("/urlRedirect", (req, res) => {
-    const url = req.query.url
-    const trackId = req.query.trackId
+    const url = req.query.url;
+    const trackId = req.query.trackId;
     if (trackId != "system") {
         urlOpender(trackId)
     }
-    if (isSafeRedirectTarget(url)) {
-        res.redirect(url)
+    const safeTarget = getAllowedRedirectTarget(url);
+    if (safeTarget) {
+        res.redirect(safeTarget)
     } else {
         res.redirect("/")
     }
@@ -85,18 +103,7 @@ const urlOpender = async (trackId: string) => {
     // }
 }
 
-// Allow only relative URLs as redirect targets
-function isSafeRedirectTarget(url: any): boolean {
-    // Only allow string, and only relative URLs (no protocol, no domain)
-    if (typeof url !== "string") return false;
-    // Disallow protocol-relative and fully qualified URLs
-    if (/^(\w+:)?\/\//.test(url)) return false;
-    // Disallow absolute file-system paths (optional)
-    // Optionally, allow only URLs starting with /
-    if (!url.startsWith("/")) return false;
-    // Optionally, add further path sanitization here
-    return true;
-}
+// The allowlist-based check is now enforced above with getAllowedRedirectTarget.
 
 // router.get("/syncGAData", async (req, res) => {
 //     const records = await getMessageRecord()


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/20](https://github.com/jkes900136/messagingSystem/security/code-scanning/20)

**General approach:**  
To fix server-side open redirects, replace any filter-based validation (such as just checking for a relative URL) with an explicit whitelist of allowed redirect destinations, or a controlled lookup/mapping using user input as a key.

**Detailed fix for the current code:**  
- Define an explicit list or mapping of allowed relative URLs (e.g., an array of permitted redirect paths).
- In the `/urlRedirect` route handler, do not pass `req.query.url` directly through validation;
  instead, check if it exactly matches one of the entries in the whitelist—if so, allow the redirect, otherwise redirect to `/`.
- Implement a helper (e.g., `getAllowedRedirectTarget`) to check membership in the allowed list.
- Change the call in the route handler so that only known safe redirects are allowed.

**What to change:**  
- In `src/messageRecordWS.ts`, define a whitelist of allowed redirect targets near the top or before the router definitions.
- Remove or replace the `isSafeRedirectTarget` logic so that explicit membership in the whitelist is enforced.
- Adjust the route handler's logic accordingly.
- No additional NPM dependencies are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
