### PR TITLE
Potential fix for code scanning alert no. 3: Server-side request forgery

### DIFF
--- a/src/fileWS.ts
+++ b/src/fileWS.ts
@@ -13,6 +13,10 @@ router.get('/getFile', async function (req, res) {
     const auth = await driveService.authorize()
     const drive = google.drive({ version: 'v3', auth });
     const fileId = req.query.fileId;
+    // Validate fileId: must be a plausible Drive file ID (alphanum, _, -, length 20-100)
+    if (typeof fileId !== "string" || !/^[a-zA-Z0-9_-]{20,100}$/.test(fileId)) {
+        return res.status(400).send('Invalid fileId');
+    }
 
     driveService.getFileById(fileId).then(async doc => {
         if (doc.exists) {


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/3](https://github.com/jkes900136/messagingSystem/security/code-scanning/3)

To fix this SSRF vulnerability, you should strictly validate that `fileId` conforms to the expected format before using it in the outgoing request. Google Drive file IDs are known to be a mix of letters, digits, hyphens, and underscores, and have a typical length range. Implement a regular expression to only allow valid Drive file IDs.

- Validate `fileId` before the outgoing request using a regular expression such as `/^[a-zA-Z0-9_-]{20,100}$/` (adjust length as needed based on your Drive usage pattern).
- If `fileId` does not match the allowed pattern, immediately return an error (e.g., HTTP 400 Bad Request).
- This check needs to be added before constructing the URL or making any API calls.
- No need to add new libraries, use plain JavaScript/TypeScript regex.
- Apply this in-place at the top of the `/getFile` route handler, just after obtaining `fileId`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
