### PR TITLE
Potential fix for code scanning alert no. 19: Missing rate limiting

### DIFF
--- a/src/workWS.ts
+++ b/src/workWS.ts
@@ -1,12 +1,21 @@
 import { Router } from "express"
 import { v4 as uuidv4 } from "uuid"
 import * as driveService from "./services/driveService"
+import rateLimit from "express-rate-limit";
 import * as receiverService from "./services/receiverService"
 import * as workService from "./services/workService"
 import { Work, Task, Item, Flow, WorkUpload, MemberOrganization } from "./model"
 import * as config from './config';
 
 const router = Router()
+
+// Set up rate limiter: max 100 requests per 15 minutes per IP
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100,
+});
+// Apply rate limiter to all routes in this router
+router.use(limiter);
 
 router.post("/createWorks", async (req, res) => {
     const workUploads = req.body as WorkUpload[]


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/19](https://github.com/jkes900136/messagingSystem/security/code-scanning/19)

To resolve the missing rate limiting vulnerability, a rate limiting middleware should be applied to the relevant route or router. In the context of Express, the widely used and well-supported `express-rate-limit` package provides a robust solution. We'll import this package and create a rate limiter (e.g., 100 requests per 15 minutes per IP as a good starting point). The rate limiter middleware should be applied to the `router` instance, so all routes defined within this router (including `/createWorks`) are protected. Minimal changes are required to add the relevant import, configure the rate limiter, and add it to the middleware stack. No existing logic or endpoints need to be altered.

**Required steps:**
- Import `express-rate-limit` at the top of the file.
- Configure the limiter (e.g., 100 requests per 15 minutes, but this is customizable).
- Use `router.use(limiter)` before defining the routes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
