### PR TITLE
Potential fix for code scanning alert no. 18: Missing rate limiting

### DIFF
--- a/src/driveCrawler.ts
+++ b/src/driveCrawler.ts
@@ -4,6 +4,15 @@ import * as googleDrive from "./services/driveService"
 var fs = require('fs');
 const router = Router()
 
+// Rate limiting middleware
+const rateLimit = require('express-rate-limit');
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+    standardHeaders: true, // Return rate limit info in the RateLimit-* headers
+    legacyHeaders: false, // Disable the X-RateLimit-* headers
+});
+router.use(limiter);
 router.post('/crawler', async function (req, res) {
     console.log("crawler");
     const auth = await googleDrive.authorize();


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/18](https://github.com/jkes900136/messagingSystem/security/code-scanning/18)

To remedy the lack of rate limiting on expensive endpoints, a rate limiting middleware should be applied to the router handling these requests. The best way, following standard Express practices, is to use the well-known `express-rate-limit` package and add a limiter middleware either to the entire router or to the most critical endpoints.

Specific steps:
- Import `express-rate-limit`.
- Define a rate limiter middleware (e.g., limiting each IP to 100 requests per 15 minutes).
- Apply the limiter to the router itself using `router.use(limiter)` so that all routes in this router are protected.
- Ensure this does not affect existing functionality except for limiting excessive requests.

**Location of changes:**  
All changes are to be made in `src/driveCrawler.ts`:
- Add the import for `express-rate-limit` at the top.
- Instantiate a limiter after router creation.
- Apply the limiter to the router before route definitions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
