### PR TITLE
Potential fix for code scanning alert no. 15: Missing rate limiting

### DIFF
--- a/src/chatbotWS.ts
+++ b/src/chatbotWS.ts
@@ -5,6 +5,7 @@ import { Stream } from 'stream';
 import * as fs from 'fs'
 import axios from "axios"
 import * as wechat from 'wechat'
+import rateLimit from "express-rate-limit";
 import { createHash } from "crypto"
 import * as mime from "mime"
 import { messageDispatcher, postbackDispatcher } from './authorizationSubscriber'
@@ -12,6 +13,7 @@ import { getMemberByAnyId, setMember, deleteFirebaseToken } from './services/mem
 import * as lineService from './services/lineService';
 const queryString = require('query-string');
 let path = require("path");
+
 
 const router = Router()
 router.post('/lineWebhook', (req, res) => {
@@ -206,7 +208,7 @@ router.use('/wechatWebhook', wechat(wechatAccount.callbackToken, function (req, 
         });
 })); // end of wechatWebhook
 
-router.use('/wechatRedir', async function (req, res) {
+router.use('/wechatRedir', wechatRedirLimiter, async function (req, res) {
     if (req.hasOwnProperty("body")) {
         console.log('Has body wechatRedir.html:', req.body)
     } else {


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/15](https://github.com/jkes900136/messagingSystem/security/code-scanning/15)

To fix the missing rate limiting, add rate limiting middleware to the `/wechatRedir` route handler. The standard and recommended way in Express.js is to use an external and well-known library such as `express-rate-limit`. Because the code does not yet import or use such a limiter, the best approach is to:

1. Import (require or import) `express-rate-limit` at the top of the file.
2. Create a limiter instance, specifying reasonable defaults for rate limiting (e.g., 100 requests per 15 minutes).
3. Apply this limiter as middleware to just the `/wechatRedir` route, to prevent breaking other application logic.

All modifications should be confined to `src/chatbotWS.ts`, including the import, definition, and application of the limiter only to the `/wechatRedir` route.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
