### PR TITLE
Potential fix for code scanning alert no. 1: Use of a broken or weak cryptographic algorithm

### DIFF
--- a/src/chatbotWS.ts
+++ b/src/chatbotWS.ts
@@ -159,7 +159,7 @@ router.use('/wechatWebhook', wechat(wechatAccount.callbackToken, function (req, 
     let t1, t2, t3;
     t1 = new Date();
     if (req.method.toLowerCase() === "get") {
-        const shasum = createHash("sha1")
+        const shasum = createHash("sha256")
         shasum.update([wechatAccount.callbackToken, req.query.timestamp, req.query.nonce].sort().join(""))
         const signature = shasum.digest("hex")
         if (signature !== req.query.signature)


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/1](https://github.com/jkes900136/messagingSystem/security/code-scanning/1)

To fix the use of a weak cryptographic algorithm in the webhook verification code, update the instantiation of the hash from SHA-1 to a strong hash function, such as SHA-256. Change the call to `createHash("sha1")` to `createHash("sha256")`. This change applies to line 162 in `src/chatbotWS.ts`. This edit will require no extra imports, as `createHash` already supports strong algorithms, and no other functionality needs changing, unless the external protocol (WeChat) _requires_ SHA-1; if so, this may require further consideration. For now, update the hash algorithm for the verification logic.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
