### PR TITLE
Potential fix for code scanning alert no. 5: Client-side cross-site scripting

### DIFF
--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -1,4 +1,5 @@
 import { createTransport } from "nodemailer"
+import he from "he"
 import Axios from "axios"
 import * as driveService from './driveService'
 import { appName, emailConfig, backendUrl } from "../config"
@@ -19,7 +20,7 @@ export const pushMessage = (email: string, options: { subject: string, message: 
             from: appName + `<${emailConfig.user}>`,
             to: email,
             subject: options.subject,
-            html: options.message,
+            html: he.encode(options.message),
             attachments: options.files
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/jkes900136/messagingSystem/security/code-scanning/5](https://github.com/jkes900136/messagingSystem/security/code-scanning/5)

To fix the HTML injection vulnerability, we must ensure that any user-provided data interpolated into HTML—specifically the message field sent via email—is robustly encoded and/or sanitized before inclusion. Since messages can contain both substituted template variables (possibly already escaped with `he.encode`), but also arbitrary input strings (including numerics not encoded, and URL values interpolated directly with string concatenation), we must contextually escape all input before HTML insertion.

For this context, escaping all unsafe HTML entities in the final message string before assignation to `mailOptions.html` is the safest approach. This is best performed by using a library such as `he` for HTML entity encoding. Specifically:
- In `src/services/emailService.ts`, before assigning `options.message` to `mailOptions.html`, ensure it is run through `he.encode`.
- Since the insertion of URLs as `<a href=...>` happens after template variable processing, code must ensure that URL and link text are also safely encoded when constructing anchor tags.
- Imports: If not already present in the file, add `import he from 'he'`.

Edits are restricted only to the region shown in `src/services/emailService.ts`. The required fix can be performed by changing line 22 in pushMessage’s mailOptions object construction as follows:
- Replace `html: options.message,` with `html: he.encode(options.message),`
Alternatively, if HTML formatting is desired (newlines, links), and the message may contain mixed content, sanitize but not encode the already-inserted tags, using a library like `sanitize-html`, but as only `he` is imported in the observable snippets, we will use `he` for entity encoding.

Optionally, ensure that anywhere a user-controlled value is interpolated as raw HTML (like forming links in `toEmailMessage`), the inserted value is encoded appropriately for its context (e.g., URL-encoding for the URL, HTML-encoding for display text).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
